### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ minikube
 *~
 .env
 capi
+kubectl


### PR DESCRIPTION
Ignores `kubectl` since it is overwritten each time `make setup` gets executed